### PR TITLE
initial commit using meson for build flow

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,32 @@
+project('mm', 'c', 'cpp')
+
+#CC       := tools/ido_recomp/$(DETECTED_OS)/7.1/cc
+#CC_OLD   := tools/ido_recomp/$(DETECTED_OS)/5.3/cc
+
+if host_machine.system() == 'linux'
+  sys = 'linux'
+elif host_machine.system() == 'darwin'
+  sys = 'macos'
+elif host_machine.system() == 'windows'
+  sys = 'windows'
+endif
+
+ido_comp_path = './tools/ido_recomp/@0@/7.1/cc'.format(sys)
+ido_comp_old_path = './tools/ido_recomp/@0@/5.3/cc'.format(sys)
+
+message(ido_comp_path)
+
+ido_comp = find_program(ido_comp_path)
+ido_comp_old = find_program(ido_comp_old_path)
+
+ELF2ROM    = find_program('./tools/buildtools/elf2rom')
+MKLDSCRIPT = find_program('./tools/buildtools/mkldscript')
+YAZ0       = find_program('./tools/buildtools/yaz0')
+ZAPD       = find_program('./tools/ZAPD/ZAPD.out')
+FADO       = find_program('./tools/fado/fado.elf')
+
+
+#setup
+subdir('tools')
+#fixbaserom = find_program('./tools/
+

--- a/meson_readme.md
+++ b/meson_readme.md
@@ -1,0 +1,16 @@
+# Building with Meson
+
+1. get meson
+
+2.setup meson build directory
+```
+meson setup <meson_builddir>
+```
+substitute any name for the build dir name
+
+3. change to `<meson_builddir>` and compile
+```
+meson compile
+```
+
+

--- a/tools/ZAPD/ExporterTest/meson.build
+++ b/tools/ZAPD/ExporterTest/meson.build
@@ -1,0 +1,9 @@
+
+exporter_srcs = ['CollisionExporter.cpp', 'RoomExporter.cpp', 'TextureExporter.cpp', 'Main.cpp']
+
+libExporterTest = static_library('ExporterTest',
+  sources: exporter_srcs,
+  # note: can ZAPD and tinyxml2 includes be convereted to objects? This will
+  # depend on the `subdir()` run structure and resolving "who runs first"
+  include_directories: [zapd_utils_inc, '../ZAPD', '../lib/tinyxml2'],
+  cpp_args:['-Wextra', '-std=c++17'])

--- a/tools/ZAPD/ZAPD/genbuildinfo.py
+++ b/tools/ZAPD/ZAPD/genbuildinfo.py
@@ -1,15 +1,21 @@
 #!/usr/bin/python3
-
+import os.path
 import argparse
 from datetime import datetime
 import getpass
 import subprocess
 
 parser = argparse.ArgumentParser()
+parser.add_argument("--opath", dest="opath", type=str, required=False)
 parser.add_argument("--devel", action="store_true")
 args = parser.parse_args()
 
-with open("build/ZAPD/BuildInfo.cpp", "w+") as buildFile:
+if args.opath:
+  ofile = os.path.join(args.opath, "BuildInfo.cpp")
+else:
+  ofile = "build/ZAPD/BuildInfo.cpp"
+
+with open(ofile, "w+") as buildFile:
     label = subprocess.check_output(["git", "describe", "--always"]).strip().decode("utf-8")
     now = datetime.now()
     if args.devel:

--- a/tools/ZAPD/ZAPDUtils/meson.build
+++ b/tools/ZAPD/ZAPDUtils/meson.build
@@ -1,0 +1,8 @@
+#ZAPDUtils
+
+zapd_utils_srcs = ['./Utils/BinaryReader.cpp', './Utils/BinaryWriter.cpp', './Utils/MemoryStream.cpp']
+
+zapd_utils_inc = include_directories('.', './Utils')
+
+#todo, added some, need to reconcile rest: CXXFLAGS ?= -Wall -Wextra -O2 -g -std=c++17
+libZAPDUtils = static_library('ZAPDUtils', zapd_utils_srcs, cpp_args:['-Wextra', '-std=c++17'])

--- a/tools/ZAPD/lib/libgfxd/meson.build
+++ b/tools/ZAPD/lib/libgfxd/meson.build
@@ -1,0 +1,9 @@
+#project('gfxd', 'c')
+
+gfxd = 'gfxd.c'
+uc_srcs = ['uc_f3d.c', 'uc_f3db.c', 'uc_f3dex.c', 'uc_f3dexb.c', 'uc_f3dex2.c']
+
+# todo, add project cflags to replicate O2, (CFLAGS = -Wall -O2 -g)
+libgfxd = static_library('gfxd', [gfxd, uc_srcs])
+
+

--- a/tools/ZAPD/meson.build
+++ b/tools/ZAPD/meson.build
@@ -1,0 +1,112 @@
+
+subdir('lib/libgfxd')
+subdir('ZAPDUtils')
+subdir('ExporterTest')
+
+# TODO include these options/args
+#ASAN ?= 0
+#DEPRECATION_ON ?= 1
+#
+#ifneq ($(ASAN),0)
+#  CXXFLAGS += -fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined
+#endif
+#ifneq ($(DEPRECATION_ON),0)
+#  CXXFLAGS += -DDEPRECATION_ON
+#endif
+
+cpp = meson.get_compiler('cpp')
+
+m_dep = cpp.find_library('m', required: true)
+dl_dep = cpp.find_library('dl', required: true)
+png_dep = dependency('png')
+
+zapd_genbuildinfo = find_program('ZAPD/genbuildinfo.py')
+if get_option('buildtype') == 'debug'
+  r = run_command('python3', zapd_genbuildinfo, '--opath', meson.current_build_dir(), '--devel', check: true)
+elif
+  r = run_command('python3', zapd_genbuildinfo, '--opath', meson.current_build_dir(), check: true)
+endif
+message(r.stdout())
+
+tinyxml2 = 'lib/tinyxml2/tinyxml2.cpp'
+
+zapd_srcs = [
+  join_paths(meson.current_build_dir(), 'BuildInfo.cpp'),
+  'ZAPD/Declaration.cpp',
+  'ZAPD/GameConfig.cpp',
+  'ZAPD/Globals.cpp',
+  'ZAPD/ImageBackend.cpp',
+  'ZAPD/Main.cpp',
+  'ZAPD/OutputFormatter.cpp',
+  'ZAPD/WarningHandler.cpp',
+  'ZAPD/ZAnimation.cpp',
+  'ZAPD/ZArray.cpp',
+  'ZAPD/ZBackground.cpp',
+  'ZAPD/ZBlob.cpp',
+  'ZAPD/ZCollision.cpp',
+  'ZAPD/ZCollisionPoly.cpp',
+  'ZAPD/ZCutscene.cpp',
+  'ZAPD/ZDisplayList.cpp',
+  'ZAPD/ZFile.cpp',
+  'ZAPD/ZLimb.cpp',
+  'ZAPD/ZMtx.cpp',
+  'ZAPD/ZPath.cpp',
+  'ZAPD/ZPlayerAnimationData.cpp',
+  'ZAPD/ZPointer.cpp',
+  'ZAPD/ZResource.cpp',
+  'ZAPD/ZScalar.cpp',
+  'ZAPD/ZSkeleton.cpp',
+  'ZAPD/ZString.cpp',
+  'ZAPD/ZSymbol.cpp',
+  'ZAPD/ZTexture.cpp',
+  'ZAPD/ZTextureAnimation.cpp',
+  'ZAPD/ZVector.cpp',
+  'ZAPD/ZVtx.cpp',
+  'ZAPD/OtherStructs/CutsceneMM_Commands.cpp',
+  'ZAPD/OtherStructs/Cutscene_Commands.cpp',
+  'ZAPD/OtherStructs/SkinLimbStructs.cpp',
+  'ZAPD/Overlays/ZOverlay.cpp',
+  'ZAPD/ZRoom/ZRoom.cpp',
+  'ZAPD/ZRoom/ZRoomCommand.cpp',
+  'ZAPD/ZRoom/Commands/EndMarker.cpp',
+  'ZAPD/ZRoom/Commands/SetActorCutsceneList.cpp',
+  'ZAPD/ZRoom/Commands/SetActorList.cpp',
+  'ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp',
+  'ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp',
+  'ZAPD/ZRoom/Commands/SetCameraSettings.cpp',
+  'ZAPD/ZRoom/Commands/SetCollisionHeader.cpp',
+  'ZAPD/ZRoom/Commands/SetCsCamera.cpp',
+  'ZAPD/ZRoom/Commands/SetCutscenes.cpp',
+  'ZAPD/ZRoom/Commands/SetEchoSettings.cpp',
+  'ZAPD/ZRoom/Commands/SetEntranceList.cpp',
+  'ZAPD/ZRoom/Commands/SetExitList.cpp',
+  'ZAPD/ZRoom/Commands/SetLightList.cpp',
+  'ZAPD/ZRoom/Commands/SetLightingSettings.cpp',
+  'ZAPD/ZRoom/Commands/SetMesh.cpp',
+  'ZAPD/ZRoom/Commands/SetMinimapChests.cpp',
+  'ZAPD/ZRoom/Commands/SetMinimapList.cpp',
+  'ZAPD/ZRoom/Commands/SetObjectList.cpp',
+  'ZAPD/ZRoom/Commands/SetPathways.cpp',
+  'ZAPD/ZRoom/Commands/SetRoomBehavior.cpp',
+  'ZAPD/ZRoom/Commands/SetRoomList.cpp',
+  'ZAPD/ZRoom/Commands/SetSkyboxModifier.cpp',
+  'ZAPD/ZRoom/Commands/SetSkyboxSettings.cpp',
+  'ZAPD/ZRoom/Commands/SetSoundSettings.cpp',
+  'ZAPD/ZRoom/Commands/SetSpecialObjects.cpp',
+  'ZAPD/ZRoom/Commands/SetStartPositionList.cpp',
+  'ZAPD/ZRoom/Commands/SetTimeSettings.cpp',
+  'ZAPD/ZRoom/Commands/SetTransitionActorList.cpp',
+  'ZAPD/ZRoom/Commands/SetWind.cpp',
+  'ZAPD/ZRoom/Commands/SetWorldMapVisited.cpp',
+  'ZAPD/ZRoom/Commands/Unused09.cpp',
+  'ZAPD/ZRoom/Commands/Unused1D.cpp',
+  'ZAPD/ZRoom/Commands/ZRoomCommandUnk.cpp']
+
+executable('ZAPD.out', [zapd_srcs, tinyxml2],
+  include_directories: [zapd_utils_inc, 'ZAPD', 'lib/elfio', 'lib/libgfxd', 'lib/tinyxml2'],
+  cpp_args: ['-std=c++17', '-Wextra', '-fno-omit-frame-pointer'],
+  link_with: [libgfxd, libZAPDUtils, libExporterTest],
+  dependencies: [m_dep, dl_dep, png_dep])
+  #link_args:['-Wl,-force_load', 'ExporterTest/ExporterTest.a'])
+
+

--- a/tools/buildtools/meson.build
+++ b/tools/buildtools/meson.build
@@ -1,0 +1,18 @@
+c_args = ['-pedantic', '-std=c99']
+
+elf2rom_srcs      = ['elf2rom.c', 'elf32.c', 'n64chksum.c', 'util.c']
+makeromfs_srcs    = ['makeromfs.c', 'n64chksum.c', 'util.c']
+mkldscript_srcs   = ['mkldscript.c', 'spec.c', 'util.c']
+reloc_prereq_srcs = ['reloc_prereq.c', 'spec.c', 'util.c']
+yaz0_srcs         = ['yaz0tool.c', 'yaz0.c', 'util.c']
+
+executable('elf2rom', elf2rom_srcs,
+  c_args: c_args)
+executable('makeromfs', makeromfs_srcs,
+  c_args: c_args)
+executable('mkldscript', mkldscript_srcs,
+  c_args: c_args)
+executable('reloc_prereg', reloc_prereq_srcs,
+  c_args: c_args)
+executable('yaz0', yaz0_srcs,
+  c_args: c_args)

--- a/tools/fado/meson.build
+++ b/tools/fado/meson.build
@@ -1,0 +1,34 @@
+# TODO add these flags
+#ifneq ($(ASAN),0)
+#  CFLAGS    += -fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined
+#endif
+
+# TODO add this define 
+#ifneq ($(EXPERIMENTAL),0)
+#  CFLAGS    += -DEXPERIMENTAL
+#endif
+
+# TODO add this check 
+## GCC is too stupid to be trusted with these warnings
+#ifeq ($(CC),gcc)
+#  WARNINGS += -Wno-implicit-fallthrough -Wno-maybe-uninitialized
+#endif
+
+fado_c_args = ['-std=c11', '-Wpedantic', '-Wshadow', '-Werror=implicit-function-declaration', '-Wvla', '-Wno-unused-function']
+
+if get_option('buildtype') == 'debug'
+  fado_c_args += '-DDEGBU_ON'
+endif
+
+fado_src_inc_dir = include_directories('./include')
+fado_fairy_inc_dir = include_directories('./lib')
+
+fado_srcs = ['./src/fado.c', './src/help.c', './src/main.c', './src/mido.c']#, 'version.inc']
+fairy_srcs = ['./lib/fairy/fairy.c', './lib/fairy/fairy_print.c']
+vc_vec_srcs = ['./lib/vc_vector/vc_vector.c']
+
+executable('fado.elf', [fado_srcs, fairy_srcs, vc_vec_srcs],
+  include_directories: [fado_src_inc_dir, fado_fairy_inc_dir],
+  c_args: fado_c_args )
+
+

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,5 @@
+
+subdir('ZAPD')
+subdir('fado')
+subdir('buildtools')
+subdir('z64compress')

--- a/tools/z64compress/meson.build
+++ b/tools/z64compress/meson.build
@@ -1,0 +1,62 @@
+
+# TODO much of the build targets in the project are placed into a static
+# "build/" location will this break later scripts? Particularly the python ones?
+# In z64compress here it wants the o/($TARGET) directory. How necessary is
+# this?
+
+# TODO add this NATIVE_OPT as an option
+# Whether to use native optimizations, specify with NATIVE_OPT=0/1 on the command line, default is 0.
+# This is not supported by all compilers which is particularly an issue on Mac, and may inhibit tests.
+# NATIVE_OPT ?= 0
+# ifeq ($(NATIVE_OPT),1)
+# 	TARGET_CFLAGS += -march=native -mtune=native
+# endif
+
+
+threads_dep = dependency('threads')
+#TODO -lm already a dependency in a lower down meson.build but is needed here,
+# should pull all dependencies into top-level meson.build
+
+z64_c_args = ['-DNDEBUG', '-s', '-Os', '-flto']
+z64compress_srcs = ['src/main.c',
+  'src/n64crc.c',
+  'src/rom.c',
+  'src/sha1.c',
+  'src/wow.c']
+
+enc_c_args = ['-DNDEBUG', '-s', '-Ofast', '-flto']
+enc_src = [
+  'src/enc/aplib.c',
+  'src/enc/lzo.c',
+  'src/enc/ucl.c',
+  'src/enc/yar.c',
+  'src/enc/yaz.c',
+  'src/enc/zx7.c',
+  'src/enc/ucl/n2b_d.c',
+  'src/enc/ucl/comp/n2b_99.c',
+  'src/enc/apultra/apultra.c',
+  'src/enc/apultra/divsufsort.c',
+  'src/enc/apultra/expand.c',
+  'src/enc/apultra/matchfinder.c',
+  'src/enc/apultra/shrink.c',
+  'src/enc/apultra/shrink_context.c',
+  'src/enc/apultra/sssort.c',
+  'src/enc/apultra/trsort.c',
+  'src/enc/lzo/lzo1x_1.c',
+  'src/enc/lzo/lzo1x_9x.c',
+  'src/enc/lzo/lzo1x_d1.c',
+  'src/enc/lzo/lzo1x_d2.c',
+  'src/enc/lzo/lzo1x_d3.c',
+  'src/enc/lzo/lzo_ptr.c']
+
+# The original make file had this recipe
+#    $(OBJ_DIR)/src/enc/%.o: CFLAGS := -DNDEBUG -s -Ofast -flto -Wall
+# which should just change the CFLAGS for sources at and after enc/* in the
+# generated list. To do that here, a static library is made with those arguments
+z64compress_enc_lib = static_library('z64compress_enc', enc_src,
+c_args:enc_c_args)
+
+executable('z64compress', z64compress_srcs,
+  c_args: z64_c_args,
+  link_with: z64compress_enc_lib,
+  dependencies: [m_dep, threads_dep])


### PR DESCRIPTION
very rough draft, there be dragons.

The `tools/` directory Makefiles have been translated. In some instances there may be compiler flags that were missed. Only tested on macos.

No make options outside of what meson provides as built-in were included either. For example, in z64compress, the "native opt" option is not here and would need to be included to pass `-march` to gcc/clang.

None of the build targets have the `install:` option. Because, for now I don't have a good understanding for what should just be left as a build product or what would be useful in an `install` location during decomp.

Unsure about next steps with some of the fixed paths that may need to be changed or adjusted for asset extraction, running the rest of the build scripts, etc. The approach was to just see what broke, why, and adjust/determine a strategy based on what scripts expected what.